### PR TITLE
RFC: Rewrite for borrowed buffers and slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,32 @@ The DMA-Buf mechanism in Linux is aimed at providing a way for the user-space to
 share memory buffers between multiple devices, without any copy.
 
 This library provides a safe abstraction over this interface for Rust.
+
+## Basic usage
+
+```
+let buf: &DmaBuf = device.get_dma_buf();
+
+{
+    // Request sync and create an access guard.
+    // Multiple read-only accesses can co-exist
+    let mmap = buf.memory_map_ro().unwrap();
+    // The actual slice
+    let data = mmap.as_slice();
+    if data.len() >= 4 {
+        println!("Data buffer: {:?}...", &data[..4]);
+    }
+} // `mmap` goes out of scope and unmaps the buffer
+
+let buf: &mut DmaBuf = device.get_dma_buf_mut();
+
+{
+    // Write access is only allowed for mutable borrows
+    let mmap_rw = buf.memory_map_rw().unwrap();
+    let data = mmap.as_slice_mut();
+    if data.len() >= 4 {
+        data[0] = 0;
+        println!("Data buffer: {:?}...", &data[..4]);
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This library provides a safe abstraction over this interface for Rust.
 ## Basic usage
 
 ```
-let buf: &DmaBuf = device.get_dma_buf();
+use dma_buf::DmaBuf;
+use dma_buf::test;
+let buf: &DmaBuf = test::get_dma_buf();
 
 {
     // Request sync and create an access guard.
@@ -21,12 +23,12 @@ let buf: &DmaBuf = device.get_dma_buf();
     }
 } // `mmap` goes out of scope and unmaps the buffer
 
-let buf: &mut DmaBuf = device.get_dma_buf_mut();
+let buf: &mut DmaBuf = test::get_dma_buf_mut();
 
 {
     // Write access is only allowed for mutable borrows
-    let mmap_rw = buf.memory_map_rw().unwrap();
-    let data = mmap.as_slice_mut();
+    let mut mmap_rw = buf.memory_map_rw().unwrap();
+    let data = mmap_rw.as_slice_mut();
     if data.len() >= 4 {
         data[0] = 0;
         println!("Data buffer: {:?}...", &data[..4]);

--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ This library provides a safe abstraction over this interface for Rust.
 
 ## Basic usage
 
-```
+```should_panic()
+
 use dma_buf::DmaBuf;
 use dma_buf::test;
+
+// This test uses a stub device, always panicking.
+// It's up to you to find a working buffer.
 let buf: &DmaBuf = test::get_dma_buf();
 
 {

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -5,7 +5,7 @@ use rustix::{
     ioctl::{ioctl, Setter, WriteOpcode},
 };
 
-use crate::BufferError;
+use crate::MapError;
 
 const DMA_BUF_BASE: u8 = b'b';
 const DMA_BUF_IOCTL_SYNC: u8 = 0;
@@ -36,39 +36,39 @@ fn dma_buf_sync_ioctl(fd: BorrowedFd<'_>, flags: u64) -> Result<(), Errno> {
     unsafe { ioctl(fd, ioctl_type) }
 }
 
-fn dma_buf_sync(fd: BorrowedFd<'_>, flags: u64) -> Result<(), BufferError> {
-    dma_buf_sync_ioctl(fd, flags).map_err(|e| BufferError::FdAccess {
+fn dma_buf_sync(fd: BorrowedFd<'_>, flags: u64) -> Result<(), MapError> {
+    dma_buf_sync_ioctl(fd, flags).map_err(|e| MapError::FdAccess {
         reason: e.to_string(),
         source: std::io::Error::from(e),
     })
 }
 
-pub(crate) fn dma_buf_begin_cpu_read_access(fd: BorrowedFd<'_>) -> Result<(), BufferError> {
+pub(crate) fn dma_buf_begin_cpu_read_access(fd: BorrowedFd<'_>) -> Result<(), MapError> {
     dma_buf_sync(fd, DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ)
 }
 
-pub(crate) fn dma_buf_begin_cpu_readwrite_access(fd: BorrowedFd<'_>) -> Result<(), BufferError> {
+pub(crate) fn dma_buf_begin_cpu_readwrite_access(fd: BorrowedFd<'_>) -> Result<(), MapError> {
     dma_buf_sync(
         fd,
         DMA_BUF_SYNC_START | DMA_BUF_SYNC_WRITE | DMA_BUF_SYNC_READ,
     )
 }
 
-pub(crate) fn dma_buf_begin_cpu_write_access(fd: BorrowedFd<'_>) -> Result<(), BufferError> {
+pub(crate) fn dma_buf_begin_cpu_write_access(fd: BorrowedFd<'_>) -> Result<(), MapError> {
     dma_buf_sync(fd, DMA_BUF_SYNC_START | DMA_BUF_SYNC_WRITE)
 }
 
-pub(crate) fn dma_buf_end_cpu_read_access(fd: BorrowedFd<'_>) -> Result<(), BufferError> {
+pub(crate) fn dma_buf_end_cpu_read_access(fd: BorrowedFd<'_>) -> Result<(), MapError> {
     dma_buf_sync(fd, DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ)
 }
 
-pub(crate) fn dma_buf_end_cpu_readwrite_access(fd: BorrowedFd<'_>) -> Result<(), BufferError> {
+pub(crate) fn dma_buf_end_cpu_readwrite_access(fd: BorrowedFd<'_>) -> Result<(), MapError> {
     dma_buf_sync(
         fd,
         DMA_BUF_SYNC_END | DMA_BUF_SYNC_WRITE | DMA_BUF_SYNC_READ,
     )
 }
 
-pub(crate) fn dma_buf_end_cpu_write_access(fd: BorrowedFd<'_>) -> Result<(), BufferError> {
+pub(crate) fn dma_buf_end_cpu_write_access(fd: BorrowedFd<'_>) -> Result<(), MapError> {
     dma_buf_sync(fd, DMA_BUF_SYNC_END | DMA_BUF_SYNC_WRITE)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,3 +350,18 @@ impl<T> Drop for MappedDmaBuf<T> {
         }
     }
 }
+
+
+/// This module exists only to make tests compile.
+pub mod test {
+    use super::*;
+
+    /// Panics. Use for testing compilation.
+    pub fn get_dma_buf() -> &'static DmaBuf {
+        unimplemented!();
+    }
+    /// Panics. Use for testing compilation.
+    pub fn get_dma_buf_mut() -> &'static mut DmaBuf {
+        unimplemented!();
+    }
+}


### PR DESCRIPTION
The original code takes ownership when mapping a buffer, which doesn't fit my use case (buffers are borrowed only to prevent multiple-write problems).
    
This change binds read|write guards to mmaps, creating 3 kinds, one for each combination. The guards then have an as_slice() method for accessing the contents of the mmaps.
    
That makes it more idiomatic to read the data, compared to passing a closure. Compared to the original, this way loses some flexibility: every change of access type between read and write requires a new mmap+munmap pair. While this could be recovered with another layer of guards, I don't expect this to hurt my use case so I didn't implement it.
    
The other flexibility lost is the ability to keep a mapped buffer around. This might be worth bringing back, depending on the cost of the mmap+munmap calls.

This is a large change, so I only look for comments: would something like that be welcome as part of the API? With any needed improvements, of course.